### PR TITLE
feat: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,9 @@
 name: Dependabot Auto-Merge
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["Test Code"]  # Name of the test-code.yml workflow
+    types:
+      - completed
     branches: [ main ]
 
 permissions:
@@ -10,7 +13,9 @@ permissions:
 jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.actor == 'dependabot[bot]'
 
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-Merge
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -157,3 +157,9 @@ poetry run python src/python_src/pull_api_documentation.py
 ## Repository History
 
 NOTE: this repository was split from [abd-vro](https://github.com/department-of-veterans-affairs/abd-vro/tree/develop/domain-ee/ee-max-cfi-app).
+
+## Automated Dependency Updates
+
+This repository uses Dependabot to keep dependencies up to date. Pull requests from Dependabot are automatically merged if:
+- All checks pass
+- The update is a minor or patch version change (major version updates require manual review)


### PR DESCRIPTION
Closes: https://github.com/department-of-veterans-affairs/abd-vro/issues/3903
- Add GitHub workflow to automatically merge Dependabot PRs when checks pass
- Add documentation about automated dependency updates to README
- Configure workflow with necessary permissions for auto-merging
- Use GitHub CLI to enable auto-merge functionality
- Auto merges only on patch, or minor, not major bumps

This change streamlines dependency management by automatically merging security and dependency updates from Dependabot when all CI checks pass.

Let's merge the below first:
https://github.com/department-of-veterans-affairs/disability-max-ratings-api/pull/28