### PR TITLE
Pin version numbers

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Install Poetry"
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
 
       - name: "Install Python"
         uses: actions/setup-python@v5

--- a/poetry.lock
+++ b/poetry.lock
@@ -694,13 +694,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pygments"
-version = "2.19.0"
+version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pygments-2.19.0-py3-none-any.whl", hash = "sha256:4755e6e64d22161d5b61432c0600c923c5927214e7c956e31c23923c89251a9b"},
-    {file = "pygments-2.19.0.tar.gz", hash = "sha256:afc4146269910d4bdfabcd27c24923137a74d562a23a320a41a55ad303e19783"},
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
 ]
 
 [package.extras]
@@ -1178,4 +1178,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.3"
-content-hash = "b1a2035c4a069abed5c21cd7cb67480980c0539b2b62b363eed4007d010e63de"
+content-hash = "44d28f0757ba39b9abc96b2a43d9a409bf081ede41d35de0597bc706942d124b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,17 +65,17 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "3.12.3"
-fastapi = "0.115.*"
-httpx = "0.28.*"
-uvicorn = {version = "0.34.*", extras = ["standard"]}
+fastapi = "0.115.6"
+httpx = "0.28.1"
+uvicorn = {version = "0.34.0", extras = ["standard"]}
 
 [tool.poetry.group.dev.dependencies]
-mypy = "1.14.*"
-pre-commit = "4.0.*"
-ruff = "0.8.*"
-pytest = "8.3.*"
-pytest-cov = "6.0.*"
-bandit = {version = "1.8.*", extras = ["toml"]}
+mypy = "1.14.1"
+pre-commit = "4.0.1"
+ruff = "0.8.6"
+pytest = "8.3.4"
+pytest-cov = "6.0.0"
+bandit = {version = "1.8.0", extras = ["toml"]}
 
 [tool.bandit]
 exclude_dirs = ["tests"]


### PR DESCRIPTION
Dependabot prs for versions that are listed like `1.8.*` will still create PRs but only modify the `poetry.lock` file. This change makes those version updates apparent in `pyproject.toml` as well.