### PR TITLE
Remove logging from REST endpoint. Simplify logging in lookup_table.py

### DIFF
--- a/src/python_src/api.py
+++ b/src/python_src/api.py
@@ -7,7 +7,6 @@ from pydantic_models import (
     Rating,
 )
 from starlette.responses import JSONResponse
-from util.logger import logger
 from util.lookup_table import MAX_RATINGS_BY_CODE, get_max_rating
 from util.sanitizer import sanitize
 
@@ -80,10 +79,7 @@ async def get_max_ratings(
             rating = Rating(diagnostic_code=int(sanitize(dc)), max_rating=max_rating)
             ratings.append(rating)
 
-    response = MaxRatingsForClaimForIncreaseResponse(ratings=ratings)
-
-    logger.info(f'event=getMaxRating response={response.model_dump_json()}')
-    return response
+    return MaxRatingsForClaimForIncreaseResponse(ratings=ratings)
 
 
 # Rough boundaries of diagnostic codes as shown by document at

--- a/src/python_src/util/logger.py
+++ b/src/python_src/util/logger.py
@@ -1,7 +1,0 @@
-import logging
-import sys
-
-logging.basicConfig(
-    format='[%(asctime)s] %(levelname)-8s %(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S', stream=sys.stdout
-)
-logger = logging.getLogger()

--- a/src/python_src/util/lookup_table.py
+++ b/src/python_src/util/lookup_table.py
@@ -1,13 +1,14 @@
 import csv
+import logging
 import os
 
 from .data.table_version import TABLE_VERSION
-from .logger import logger
 
 TABLE_NAME = 'Diagnostic Code Lookup Table.csv'
 
 
 def get_max_ratings_by_code() -> dict[int, int]:
+    logger = logging.getLogger('uvicorn.error')
     logger.info(f'Loading Disability Max Ratings from Diagnostic Code Lookup Table v{TABLE_VERSION}')
 
     filename = os.path.join(os.path.dirname(__file__), 'data', TABLE_NAME)


### PR DESCRIPTION
Result from Architecture Intent meeting. Essentially when we log a statement with the diagnostic codes, that can potentially de-anonymize the veteran.
