### PR TITLE
Specify token on checkout

### DIFF
--- a/.github/workflows/update-poetry-lock.yml
+++ b/.github/workflows/update-poetry-lock.yml
@@ -23,6 +23,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+          # token with read/write repo access for abd-vro-machine
+          token: ${{ secrets.ABD_VRO_MACHINE_READ_WRITE_REPO }}
 
       - name: Check Poetry version in lock file
         id: check_poetry_version


### PR DESCRIPTION
from this discussion: https://github.com/orgs/community/discussions/25702#discussioncomment-3248819

> If an action pushes code using the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.