### PR TITLE
Prevent build and push to ECR if image tag already exists.

### DIFF
--- a/.github/workflows/build_and_push_to_ecr.yml
+++ b/.github/workflows/build_and_push_to_ecr.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Run every day at midnight UTC - this is a workaround to ensure the workflow is run at least once per day since
+    # VA GitHub enterprise settings prevent github actions from running as a result of dependabot PRs.
+    - cron: '0 0 * * *'
 
 concurrency:
   group: build-and-push-${{ github.ref }}


### PR DESCRIPTION
Due to enterprise VA settings, PRs merged into `main` do not result in github actions running, this will force builds to be eventually consistent with what is on the `main` branch. 