### PR TITLE
Change to allow sha from any branch.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,24 +46,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate SHA exists in main branch
+      - name: Validate SHA exists on current branch
         id: validate-sha
         run: |
-          git fetch origin main
-          if git merge-base --is-ancestor ${{ github.event.inputs.commit_sha }} origin/main; then
-            echo "SHA ${{ github.event.inputs.commit_sha }} exists in main branch"
+          git fetch origin ${{ github.ref_name }}
+          if git merge-base --is-ancestor ${{ github.event.inputs.commit_sha }} origin/${{ github.ref_name }}; then
+            echo "SHA ${{ github.event.inputs.commit_sha }} exists on branch ${{ github.ref_name }}"
             echo "validated_sha=${{ github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
           else
-            echo "Error: SHA ${{ github.event.inputs.commit_sha }} does not exist in main branch"
+            echo "Error: SHA ${{ github.event.inputs.commit_sha }} does not exist on branch ${{ github.ref_name }}"
             exit 1
           fi
 
   prepare-environments:
     runs-on: ubuntu-latest
     needs: [validate-sha]
-    if: >
-      github.event.inputs.commit_sha == '' ||
-      (github.event.inputs.commit_sha != '' && needs.validate-sha.result == 'success')
+    if: needs.validate-sha.result == 'success' || needs.validate-sha.result == 'skipped'
     outputs:
       environments: ${{ steps.set-environments.outputs.environments }}
     steps:
@@ -82,11 +80,12 @@ jobs:
         run: |
           echo "environments=${{ env.environments }}" >> $GITHUB_OUTPUT
 
-  update_image_tag:
+  update-image-tag:
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')) &&
+      (needs.validate-sha.result == 'success' || needs.validate-sha.result == 'skipped')
     needs:
       - prepare-environments
       - validate-sha


### PR DESCRIPTION
## Workflow Execution Scenarios

### **Scenario 1: Manual dispatch with empty `commit_sha`**
1. **`validate-sha`**: ❌ **SKIPPED** (no SHA provided)
2. **`prepare-environments`**: ✅ **RUNS** (condition: `needs.validate-sha.result == 'skipped'`)
3. **`update_image_tag`**: ✅ **RUNS** (uses latest SHA from workflow branch: `${{ github.sha }}`)

### **Scenario 2: Manual dispatch with valid `commit_sha`**
1. **`validate-sha`**: ✅ **RUNS** and **SUCCEEDS** (SHA exists on current branch)
2. **`prepare-environments`**: ✅ **RUNS** (condition: `needs.validate-sha.result == 'success'`)
3. **`update_image_tag`**: ✅ **RUNS** (uses provided validated SHA)

### **Scenario 3: Manual dispatch with invalid `commit_sha`** 
1. **`validate-sha`**: ❌ **RUNS** and **FAILS** (SHA doesn't exist on current branch)
2. **`prepare-environments`**: ❌ **SKIPPED** (validation failed)
3. **`update_image_tag`**: ❌ **SKIPPED** (depends on `prepare-environments`)

### **Scenario 4: Automatic trigger from ECR build**
1. **`validate-sha`**: ❌ **SKIPPED** (no manual input)
2. **`prepare-environments`**: ✅ **RUNS** (condition: `needs.validate-sha.result == 'skipped'`)
3. **`update_image_tag`**: ✅ **RUNS** (uses latest SHA from main branch: `${{ github.sha }}`)

## Key Changes
- **Fixed dependency chain**: Removed circular dependency issues that prevented execution when `commit_sha` was empty
- **Enhanced SHA validation**: Now validates that provided SHA exists on the current workflow branch
- **Proper failure handling**: Workflow stops all deployment activities if an invalid SHA is provided
- **Simplified conditions**: Removed redundant checks and clarified job dependencies