### PR TITLE
Fix undefined default issue.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         required: false
   workflow_run:
     workflows:
-      - 'Build and push to ECR'
+      - 'Build and Push to ECR'
     branches:
       - main
     types:
@@ -37,7 +37,7 @@ permissions:
 jobs:
   validate-sha:
     runs-on: ubuntu-latest
-    if: github.event.inputs.commit_sha != ''
+    if: ${{ github.event.inputs.commit_sha }}
     outputs:
       validated_sha: ${{ steps.validate-sha.outputs.validated_sha }}
     steps:


### PR DESCRIPTION
Now the condition ${{ github.event.inputs.commit_sha }} will be:
* false when the input is empty string '', null, undefined, or not provided
* true only when there's actual content in the input
This should fix the issue. Now when you run the workflow manually without entering a SHA:
* validate-sha: ❌ SKIPPED (condition is false for empty/null input)
* prepare-environments: ✅ RUNS (condition: needs.validate-sha.result == * 'skipped' will be true)
* update_image_tag: ✅ RUNS (same logic)