### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -4,6 +4,10 @@ on:
   workflow_call: # Allows this workflow to be called from another workflow
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+  secrets: read
+
 jobs:
   perform-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/department-of-veterans-affairs/disability-max-ratings-api/security/code-scanning/1](https://github.com/department-of-veterans-affairs/disability-max-ratings-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code.
- `secrets: read` for accessing the `CC_TEST_REPORTER_ID` secret used in the "Upload coverage to Code Climate" step.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
