### PR TITLE
Fix copilot blunder

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -30,7 +30,6 @@ on:
 
 permissions:
   contents: read
-  secrets: read
 
 jobs:
   perform-checks:


### PR DESCRIPTION
Fix issue Copilot caused by making up a permissions category for workflows as part of its "fix" for a CodeQL security vulnerability.