### PR TITLE
feat(build_and_push_to_ecr.yml): Commitizen versioning automation

### DIFF
--- a/.github/workflows/build_and_push_to_ecr.yml
+++ b/.github/workflows/build_and_push_to_ecr.yml
@@ -40,6 +40,35 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
+
+  cz-bump:
+    name: Bump version with Commitizen
+    #needs: build-and-push-to-ecr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Commitizen
+        run: pip install commitizen
+
+      - name: Bump version
+        run: | # This step will bump the version based on the commit messages
+          cz bump --yes
+
+      - name: Push bump commit & tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin HEAD --follow-tags
+
   build-and-push-to-ecr:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build_and_push_to_ecr.yml
+++ b/.github/workflows/build_and_push_to_ecr.yml
@@ -37,7 +37,7 @@ concurrency:
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: write  # This is required for actions/checkout and pushing commits/tags
 
 jobs:
 

--- a/.github/workflows/build_and_push_to_ecr.yml
+++ b/.github/workflows/build_and_push_to_ecr.yml
@@ -53,9 +53,9 @@ jobs:
           persist-credentials: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12.3'
 
       - name: Install Commitizen
         run: pip install commitizen


### PR DESCRIPTION
**The cz-bump job:**

**Summary**
- Checks out full history (fetch-depth: 0) so Commitizen can see prior tags.
- Installs Python & Commitizen.
- Runs cz bump --yes (updates pyproject.toml, commits, tags).
- Pushes both the new commit and vX.Y.Z tag back to main.

This change enhances our existing build_and_push_to_ecr.yml workflow by adding a post-build job that uses Commitizen to automatically bump the project version, commit the bump, update the changelog and push a new Git tag.
